### PR TITLE
Убрал проверку токена на публичных запросах

### DIFF
--- a/src/main/java/hh/forest_of_habits/config/JwtRequestFilter.java
+++ b/src/main/java/hh/forest_of_habits/config/JwtRequestFilter.java
@@ -12,10 +12,12 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.servlet.HandlerExceptionResolver;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 
 @Component
@@ -27,6 +29,8 @@ public class JwtRequestFilter extends OncePerRequestFilter {
 
     private final JwtTokenUtils jwtTokenUtils;
     private final HandlerExceptionResolver handlerExceptionResolver;
+
+    private final SecurityProperties securityProperties;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,
@@ -56,5 +60,11 @@ public class JwtRequestFilter extends OncePerRequestFilter {
         }
 
         filterChain.doFilter(request, response);
+    }
+
+    @Override
+    protected boolean shouldNotFilter(@NonNull HttpServletRequest request) {
+        return Arrays.stream(securityProperties.getIgnored())
+                .anyMatch(e -> new AntPathMatcher().match(e, request.getServletPath()));
     }
 }

--- a/src/main/java/hh/forest_of_habits/controller/ForestController.java
+++ b/src/main/java/hh/forest_of_habits/controller/ForestController.java
@@ -11,9 +11,11 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+import java.util.UUID;
 
 @RequiredArgsConstructor
 @RestController
@@ -49,5 +51,25 @@ public class ForestController {
     @GetMapping("/friends")
     public List<ForestResponse> getFriendsForests() {
         return forestService.getFriendsForests();
+    }
+
+    @PutMapping("/share/{id}")
+    UUID makeShared(@PathVariable Long id) {
+        return forestService.makeShared(id, true);
+    }
+
+    @PutMapping("/share")
+    void makeShared(@RequestParam Long forestId, @RequestParam Long userId) {
+        forestService.makeShared(forestId, userId, true);
+    }
+
+    @DeleteMapping("/share/{id}")
+    void makeUnshared(@PathVariable Long id) {
+        forestService.makeShared(id, false);
+    }
+
+    @DeleteMapping("/share")
+    void makeUnshared(@RequestParam Long forestId, @RequestParam Long userId) {
+        forestService.makeShared(forestId, userId, false);
     }
 }

--- a/src/main/java/hh/forest_of_habits/controller/ShareController.java
+++ b/src/main/java/hh/forest_of_habits/controller/ShareController.java
@@ -9,9 +9,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.DeleteMapping;
 
 import java.util.UUID;
 
@@ -30,25 +27,5 @@ public class ShareController {
     @GetMapping("/tree/{id}")
     TreeFullResponse getTree(@PathVariable Long id) {
         return treeService.getById(id);
-    }
-
-    @PutMapping("/{id}")
-    UUID makeShared(@PathVariable Long id) {
-        return forestService.makeShared(id, true);
-    }
-
-    @PutMapping
-    void makeShared(@RequestParam Long forestId, @RequestParam Long userId) {
-        forestService.makeShared(forestId, userId, true);
-    }
-
-    @DeleteMapping("/{id}")
-    void makeUnshared(@PathVariable Long id) {
-        forestService.makeShared(id, false);
-    }
-
-    @DeleteMapping
-    void makeUnshared(@RequestParam Long forestId, @RequestParam Long userId) {
-        forestService.makeShared(forestId, userId, false);
     }
 }


### PR DESCRIPTION
Убрал проверку токена на эндпойнтах, не требующих отправку токена. Если у пользователя был устаревший токен, то могла возникнуть ошибка устаревшего токена, даже если он не нужен. 
Перенес методы для создания/ удаления шаринга леса из /shared, так как они требуют валидного токена. В /shared  оставил только методы для просмотра леса и деревьев, для которых не нужен токен